### PR TITLE
trigger product update modal

### DIFF
--- a/web/src/components/Auth/EmailPassword/EmailPasswordSignupForm.tsx
+++ b/web/src/components/Auth/EmailPassword/EmailPasswordSignupForm.tsx
@@ -1,5 +1,6 @@
 import { CircularProgress } from "@mui/material";
 import { useState } from "react";
+import { useDispatch } from "react-redux";
 import CustomButton from "../../common/CustomButton/index.tsx";
 import { Toast } from "../../Toast.tsx";
 import { useNavigate } from "react-router-dom";
@@ -10,9 +11,12 @@ import {
 import CustomInput from "../../Inputs/CustomInput.tsx";
 import { InputTypes } from "../../../types/inputs/inputTypes.ts";
 import ShowPasswordIcon from "./ShowPasswordIcon.tsx";
+import { setCommonKey } from "../../../store/features/common/commonSlice.ts";
 
 function EmailPasswordSignupForm() {
   const navigate = useNavigate();
+  const dispatch = useDispatch();
+
   const [error, setError] = useState("");
   const [btnLoading, setBtnLoading] = useState(false);
   const [triggerSignup, { isLoading }] = useSignupMutation();
@@ -34,6 +38,15 @@ function EmailPasswordSignupForm() {
 
   function redirectToLoginAfterSignup() {
     navigate("/login");
+  }
+
+  function deleteLastLogin() {
+    localStorage.removeItem("last_login")
+
+    dispatch(setCommonKey({
+      key: "productUpdateStatus",
+      value : false }
+    ));
   }
 
   const getError = (err) => {
@@ -66,6 +79,7 @@ function EmailPasswordSignupForm() {
       setPassword("");
       setFirstName("");
       setLastName("");
+      deleteLastLogin();
 
       redirectToLoginAfterSignup();
     } catch (err) {

--- a/web/src/components/Modals/RecieveUpdatesModal/index.tsx
+++ b/web/src/components/Modals/RecieveUpdatesModal/index.tsx
@@ -29,7 +29,7 @@ const RecieveUpdatesModal = ({ isOpen, close }) => {
 
   return (
     <div className="z-50">
-      <Overlay close={close} visible={isOpen}>
+      <Overlay close={() => {handleProductUpdateSignup(false)}} visible={isOpen}>
         <div className="relative bg-white py-6 px-4 rounded max-w-full w-[300px]">
           <div
             onClick={close}

--- a/web/src/components/Modals/RecieveUpdatesModal/index.tsx
+++ b/web/src/components/Modals/RecieveUpdatesModal/index.tsx
@@ -1,23 +1,25 @@
 import React, { useEffect } from "react";
+import { useDispatch } from "react-redux";
 import Overlay from "../../Overlay/index.tsx";
 import { CloseRounded } from "@mui/icons-material";
 import CustomButton from "../../common/CustomButton/index.tsx";
 import posthog from "posthog-js";
+import { setCommonKey } from "../../../store/features/common/commonSlice.ts";
 
 const RecieveUpdatesModal = ({ isOpen, close }) => {
-  const handleYes = () => {
-    posthog.capture("POST_LOGIN_SUBSCRIPTION_UPDATE_INTERACTED", {
-      subscription_requested: true,
-    });
-    close();
-  };
+  const dispatch = useDispatch();
 
-  const handleNo = () => {
+  const handleProductUpdateSignup = (signupStatus: boolean) => {
+    dispatch(setCommonKey({
+      key: "productUpdateStatus",
+      value : true }
+    ));
+
     posthog.capture("POST_LOGIN_SUBSCRIPTION_UPDATE_INTERACTED", {
-      subscription_requested: false,
+      subscription_requested: signupStatus,
     });
     close();
-  };
+  }
 
   useEffect(() => {
     if (isOpen) {
@@ -41,11 +43,11 @@ const RecieveUpdatesModal = ({ isOpen, close }) => {
 
           <div className="flex items-center gap-2 mt-4">
             <CustomButton
-              onClick={handleYes}
+              onClick={() => handleProductUpdateSignup(true)}
               className="!bg-violet-500 !text-white hover:!text-violet-500 hover:!bg-transparent">
               Yes Please!
             </CustomButton>
-            <CustomButton onClick={handleNo}>No thanks</CustomButton>
+            <CustomButton onClick={() => handleProductUpdateSignup(false)}>No thanks</CustomButton>
           </div>
         </div>
       </Overlay>

--- a/web/src/components/RequireAuth.tsx
+++ b/web/src/components/RequireAuth.tsx
@@ -4,6 +4,7 @@ import {
   selectAccessToken,
   selectLastLogin,
 } from "../store/features/auth/authSlice.ts";
+import { commonKeySelector } from "../store/features/common/selectors/commonKeySelector.ts";
 import FakeLoading from "./common/Loading/FakeLoading.tsx";
 import RecieveUpdatesModal from "./Modals/RecieveUpdatesModal/index.tsx";
 import useToggle from "../hooks/common/useToggle.js";
@@ -11,6 +12,7 @@ import useToggle from "../hooks/common/useToggle.js";
 const RequireAuth = () => {
   const accessToken = useSelector(selectAccessToken);
   const lastLogin = useSelector(selectLastLogin);
+  const commonKey = useSelector(commonKeySelector)
   const location = useLocation();
   const { isOpen, toggle } = useToggle(true);
 
@@ -28,9 +30,7 @@ const RequireAuth = () => {
         <Navigate to="/signup" state={{ from: location }} replace />
       )}
 
-      {/* {!lastLogin && (
-        <RecieveUpdatesModal close={handleClose} isOpen={isOpen} />
-      )} */}
+      {!lastLogin && !commonKey.productUpdateStatus && <RecieveUpdatesModal close={toggle} isOpen={isOpen} />}
     </>
   );
 };

--- a/web/src/store/features/common/initialState.ts
+++ b/web/src/store/features/common/initialState.ts
@@ -3,6 +3,7 @@ export type InitialStateType = {
   connectorOptions?: any[];
   supportedTaskTypes?: any[];
   interpreterTypes?: any[];
+  productUpdateStatus?: any;
 };
 
 export const initialState: InitialStateType = {
@@ -10,4 +11,5 @@ export const initialState: InitialStateType = {
   connectorOptions: [],
   supportedTaskTypes: [],
   interpreterTypes: [],
+  productUpdateStatus: false,
 };


### PR DESCRIPTION
There's a small issue for first-time users where every page will show the Product Update Modal to the customer.

Playbooks currently depends on setting the last-login time cookie to know if this modal should be displayed or not. There's 2 issues with this:

New customers from the same browser won't get the chance to sign up for product updates
A first time customer will just face annoyances for the first time they interact with Playbooks' platform.
This PR fixes that by ensuring that on registering we focus on the new customer through setting the option in the redux store and clearing the last-login time cookie on re-registering

I've added 2 videos below. The first one shows the issue and the second validates the fix.

Issue:
https://github.com/user-attachments/assets/2f6c0db1-cc50-4bad-8b9c-fd38516a8887

Validated Fix:

https://github.com/user-attachments/assets/7abf09e4-aaa2-4036-aa77-f4ea7a6cbe93





